### PR TITLE
Array columns pivoted by passband

### DIFF
--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -37,20 +37,25 @@ def _merge_all(aggregated_dfs: list[sql.DataFrame],
     return reduce(lambda df1, df2: df1.join(df2, on=join_key), aggregated_dfs)
 
 
-def make_array_cols(df: sql.DataFrame, key: str, filter_col:str) -> sql.DataFrame:
+def make_array_cols(df: sql.DataFrame, key: str, filter_col:str, order_by: str = None) -> sql.DataFrame:
     """Transform df to array-valued columns.
 
     Args:
         df (sql.DataFrame): Dataframe in wide format.
         key (str): Unique key to group by.
-        filter_col (str): Column (int) containing passbands to pivot on
+        filter_col (str): Column (int) containing passbands to pivot on.
+        order_by (str): Column to sort data by (thus sorting resulting arrays on this column).
 
     Returns:
         sql.DataFrame: Dataframe with array-valued columns.
     """
 
-    assert key in df.columns, f"Key {key} not in columns of dataframe {df}"
-    assert filter_col in df.columns, f"Filter columns {filter_col} not in columns of dataframe {df}"
+    for col in [key, filter_col]:
+        assert col in df.columns, f"Column {col} not in dataframe {df}"
+
+    if order_by:
+        df = df.orderBy(order_by)
+        assert order_by in df.columns, f"Column {order_by} not in dataframe {df}"
 
     grouped = _transform_passbands(df = df, 
                                    filter_col=filter_col, 

--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -61,7 +61,7 @@ def make_array_cols(df: sql.DataFrame, key: str, filter_col:str, order_by: Union
         sql.DataFrame: Dataframe with array-valued columns.
     """
 
-    df = _cast_by_regex(df, pattern=r"aperMag|averageConf|modelDistSec|classStats", 
+    df = _cast_by_regex(df, pattern=r"aperMag|averageConf|modelDistSec|classStat", 
                         cast_to=sql.types.FloatType())
     df = _cast_by_regex(df, pattern=r"objID|multiframeID", cast_to=sql.types.IntegerType())
     df = _cast_by_regex(df, pattern=r"extNums", cast_to=sql.types.ByteType())

--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -2,11 +2,27 @@ from pyspark import sql
 from pyspark.sql.functions import collect_list
 from functools import reduce
 
+def transform_passbands(df: sql.DataFrame, filter_col: str = "filterID", new_col_name: str = "passband"):
+    """Convert numeric filter references to letter-encoded passbands"""
+    passbands_dict = {"1": "Z",
+                      "2": "Y",
+                      "3": "J",
+                      "4": "H",
+                      "5": "K",
+                      "8": "blank"}
+    return df.withColumn(new_col_name, df[filter_col].cast("string")).replace(passbands_dict, subset=[new_col_name])
+    
+def _rename_pivoted_columns(df: sql.DataFrame, col_name: str):
+    """Append feature names to passband column names e.g. J -> J_mjd"""
+    old_columns = df.columns[1:]
+    new_columns = [col + f"_{col_name}" for col in old_columns]
+    return reduce(lambda df, idx: df.withColumnRenamed(old_columns[idx], new_columns[idx]), range(len(old_columns)), df)
 
-def aggregate_by_key(grouped_df: sql.group.GroupedData,
-                     col_name: str) -> sql.DataFrame:
-    """Aggregate by key into lists e.g. (sourceID, [val1, val2, val3])"""
-    return grouped_df.agg(collect_list(col_name).alias(col_name))
+def pivot_aggregate_col(grouped_df: sql.group.GroupedData,
+                     col_name: str, pivot_on: str = "passband") -> sql.DataFrame:
+    """Aggregate column by key into lists and pivot on other column e.g. passband"""
+    aggregated = grouped_df.pivot(pivot_on).agg(sql.functions.collect_list(col_name))
+    return _rename_pivoted_columns(aggregated, col_name)
 
 
 def merge_all(aggregated_dfs: list[sql.DataFrame],
@@ -15,18 +31,21 @@ def merge_all(aggregated_dfs: list[sql.DataFrame],
     return reduce(lambda df1, df2: df1.join(df2, on=join_key), aggregated_dfs)
 
 
-def make_array_cols(df: sql.DataFrame, key: str) -> sql.DataFrame:
+def make_array_cols(df: sql.DataFrame, key: str, filter_col:str) -> sql.DataFrame:
     """Transform df to array-valued columns.
 
     Args:
         df (sql.DataFrame): Dataframe in wide format.
         key (str): Unique key to group by.
+        filter_col (str): Column (int) containing passbands to pivot on
 
     Returns:
         sql.DataFrame: Dataframe with array-valued columns.
     """
     assert key in df.columns, f"Key {key} not in columns of dataframe {df}"
+    df = transform_passbands(df, filter_col="filterID", new_col_name = "passband").drop(filter_col)
     grouped = df.groupBy(key)
-    aggregated_dfs = [aggregate_by_key(grouped_df=grouped, col_name=col_name)
-                      for col_name in df.columns if col_name != key]
+    aggregated_dfs = [pivot_aggregate_col(grouped_df=grouped, col_name=col_name, pivot_on="passband")
+                      for col_name in df.columns if col_name not in [key, "passband"]]
     return merge_all(aggregated_dfs, key)
+

--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -61,9 +61,10 @@ def make_array_cols(df: sql.DataFrame, key: str, filter_col:str, order_by: Union
         sql.DataFrame: Dataframe with array-valued columns.
     """
 
-    df = _cast_by_regex(df, pattern=r"aperMag|averageConf|modelDistSec|objID|multiframeID|classStats", 
+    df = _cast_by_regex(df, pattern=r"aperMag|averageConf|modelDistSec|classStats", 
                         cast_to=sql.types.FloatType())
-    df = _cast_by_regex(df, pattern="extNums", cast_to=sql.types.ByteType())
+    df = _cast_by_regex(df, pattern=r"objID|multiframeID", cast_to=sql.types.IntegerType())
+    df = _cast_by_regex(df, pattern=r"extNums", cast_to=sql.types.ByteType())
 
     for col in [key, filter_col]:
         if col not in df.columns:

--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -1,8 +1,7 @@
 from pyspark import sql
-from pyspark.sql.functions import collect_list
 from functools import reduce
 
-def transform_passbands(df: sql.DataFrame, filter_col: str = "filterID", new_col_name: str = "passband"):
+def _transform_passbands(df: sql.DataFrame, filter_col: str = "filterID", new_col_name: str = "passband"):
     """Convert numeric filter references to letter-encoded passbands"""
     passbands_dict = {"1": "Z",
                       "2": "Y",
@@ -10,22 +9,29 @@ def transform_passbands(df: sql.DataFrame, filter_col: str = "filterID", new_col
                       "4": "H",
                       "5": "K",
                       "8": "blank"}
-    return df.withColumn(new_col_name, df[filter_col].cast("string")).replace(passbands_dict, subset=[new_col_name])
+    return df.withColumn(new_col_name, 
+                         df[filter_col]\
+                            .cast("string"))\
+                            .replace(passbands_dict, subset=[new_col_name])
     
-def _rename_pivoted_columns(df: sql.DataFrame, col_name: str):
+def _rename_pivoted_columns(df: sql.DataFrame, key:str, col_name: str):
     """Append feature names to passband column names e.g. J -> J_mjd"""
-    old_columns = df.columns[1:]
+    old_columns = [col for col in df.columns if col != key]
     new_columns = [col + f"_{col_name}" for col in old_columns]
-    return reduce(lambda df, idx: df.withColumnRenamed(old_columns[idx], new_columns[idx]), range(len(old_columns)), df)
+    return reduce(lambda df, idx: df.withColumnRenamed(old_columns[idx], 
+                                                       new_columns[idx]), 
+                                                       range(len(old_columns)), df)
 
-def pivot_aggregate_col(grouped_df: sql.group.GroupedData,
+def _pivot_aggregate_col(grouped_df: sql.group.GroupedData, key:str,
                      col_name: str, pivot_on: str = "passband") -> sql.DataFrame:
     """Aggregate column by key into lists and pivot on other column e.g. passband"""
-    aggregated = grouped_df.pivot(pivot_on).agg(sql.functions.collect_list(col_name))
-    return _rename_pivoted_columns(aggregated, col_name)
+    aggregated = grouped_df\
+        .pivot(pivot_on)\
+        .agg(sql.functions.collect_list(col_name))
+    return _rename_pivoted_columns(df = aggregated, key = key, col_name = col_name)
 
 
-def merge_all(aggregated_dfs: list[sql.DataFrame],
+def _merge_all(aggregated_dfs: list[sql.DataFrame],
               join_key: str) -> sql.DataFrame:
     """Sequentially merge all dataframes in list to single df."""
     return reduce(lambda df1, df2: df1.join(df2, on=join_key), aggregated_dfs)
@@ -42,10 +48,15 @@ def make_array_cols(df: sql.DataFrame, key: str, filter_col:str) -> sql.DataFram
     Returns:
         sql.DataFrame: Dataframe with array-valued columns.
     """
+
     assert key in df.columns, f"Key {key} not in columns of dataframe {df}"
-    df = transform_passbands(df, filter_col="filterID", new_col_name = "passband").drop(filter_col)
-    grouped = df.groupBy(key)
-    aggregated_dfs = [pivot_aggregate_col(grouped_df=grouped, col_name=col_name, pivot_on="passband")
-                      for col_name in df.columns if col_name not in [key, "passband"]]
-    return merge_all(aggregated_dfs, key)
+    assert filter_col in df.columns, f"Filter columns {filter_col} not in columns of dataframe {df}"
+
+    grouped = _transform_passbands(df = df, 
+                                   filter_col=filter_col, 
+                                   new_col_name = "passband").drop(filter_col).groupBy(key)
+    aggregated_dfs = [_pivot_aggregate_col(grouped_df=grouped, key=key, 
+                                           col_name=col_name, pivot_on="passband")
+                      for col_name in df.columns if col_name not in [key, filter_col, "passband"]]
+    return _merge_all(aggregated_dfs, key)
 

--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -63,11 +63,13 @@ def make_array_cols(df: sql.DataFrame, key: str, filter_col:str, order_by: str =
     df = _cast_to_single_floats(df, pattern=r"aperMag|averageConf|modelDistSec")
 
     for col in [key, filter_col]:
-        assert col in df.columns, f"Column {col} not in dataframe {df}"
+        if col not in df.columns:
+            raise ValueError(f"Column {col} not in dataframe {df}")
 
     if order_by:
         df = df.orderBy(order_by)
-        assert order_by in df.columns, f"Column {order_by} not in dataframe {df}"
+        if order_by not in df.columns:
+            raise ValueError(f"Column {order_by} not in dataframe {df}")
 
     grouped = _transform_passbands(df = df, 
                                    filter_col=filter_col, 

--- a/satools/array_columns.py
+++ b/satools/array_columns.py
@@ -63,7 +63,7 @@ def make_array_cols(df: sql.DataFrame, key: str, filter_col:str, order_by: Union
 
     df = _cast_by_regex(df, pattern=r"aperMag|averageConf|modelDistSec|classStat", 
                         cast_to=sql.types.FloatType())
-    df = _cast_by_regex(df, pattern=r"objID|multiframeID", cast_to=sql.types.IntegerType())
+    df = _cast_by_regex(df, pattern=r"objID", cast_to=sql.types.IntegerType())
     df = _cast_by_regex(df, pattern=r"extNums", cast_to=sql.types.ByteType())
 
     for col in [key, filter_col]:

--- a/satools/test_array_columns.py
+++ b/satools/test_array_columns.py
@@ -1,7 +1,7 @@
 import pytest
 from pyspark.testing import assertDataFrameEqual
 from pyspark.sql import SparkSession
-from array_columns import transform_passbands, pivot_aggregate_col, merge_all, make_array_cols
+from array_columns import _transform_passbands, _pivot_aggregate_col, _merge_all, make_array_cols
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def sample_data(spark_context):
 
 def test_transform_passbands(sample_data, spark_context):
 
-    actual = transform_passbands(sample_data, filter_col="filterID", new_col_name="passband")
+    actual = _transform_passbands(sample_data, filter_col="filterID", new_col_name="passband")
     expected = spark_context.createDataFrame(
         [
         (1, 1, 1.234, 2.567, "Z"),
@@ -55,10 +55,10 @@ def test_transform_passbands(sample_data, spark_context):
 
     assertDataFrameEqual(actual, expected)
 
-def test_pivot_aggregate_columns(sample_data, spark_context):
-    df = transform_passbands(sample_data, filter_col="filterID", new_col_name="passband")
+def test_pivot_aggregate_col(sample_data, spark_context):
+    df = _transform_passbands(sample_data, filter_col="filterID", new_col_name="passband")
     grouped = df.groupBy("sourceID")
-    actual = pivot_aggregate_col(grouped, col_name="mjd", pivot_on="passband")
+    actual = _pivot_aggregate_col(grouped, key="sourceID", col_name="mjd", pivot_on="passband")
     expected = spark_context.createDataFrame(
     [
         (1, [7.234], [5.234], [9.234], [3.234], [1.234]),       
@@ -69,7 +69,7 @@ def test_pivot_aggregate_columns(sample_data, spark_context):
     
     assertDataFrameEqual(actual, expected)
 
-def test_merge_all(spark_context, sample_data):
+def test_merge_all(spark_context):
 
     agg_df = spark_context.createDataFrame(
         [
@@ -82,12 +82,9 @@ def test_merge_all(spark_context, sample_data):
     df2 = agg_df.select("id", "col2")
     df3 = agg_df.select("id", "col3")
 
-    merged = merge_all([df1, df2, df3], "id")
+    merged = _merge_all([df1, df2, df3], "id")
 
     assertDataFrameEqual(merged, agg_df)
-
-
-
 
 def test_make_array_cols(spark_context, sample_data):
     expected = spark_context.createDataFrame(

--- a/satools/test_array_columns.py
+++ b/satools/test_array_columns.py
@@ -133,6 +133,6 @@ def test_make_array_cols(spark_context, sample_data):
     actual = make_array_cols(sample_data, key="sourceID", filter_col="filterID")
     assertDataFrameEqual(actual, expected)
 
-@pytest.mark.xfail(raises=AssertionError)
 def test_make_array_cols_with_bad_colname(spark_context, sample_data):
-    make_array_cols(sample_data, key="this_key_should_throw_an_exception", filter_col="filterID", order_by="mjd")
+    with pytest.raises(ValueError):
+        make_array_cols(sample_data, key="this_key_should_throw_an_exception", filter_col="filterID", order_by="mjd")

--- a/satools/test_array_columns.py
+++ b/satools/test_array_columns.py
@@ -1,7 +1,7 @@
 import pytest
 from pyspark.testing import assertDataFrameEqual
 from pyspark.sql import SparkSession
-from array_columns import aggregate_by_key, merge_all, make_array_cols
+from array_columns import transform_passbands, pivot_aggregate_col, merge_all, make_array_cols
 
 
 @pytest.fixture
@@ -11,33 +11,63 @@ def spark_context():
 
 @pytest.fixture
 def sample_data(spark_context):
+    return spark_context.createDataFrame(
+    [
+        (1, 1, 1.234, 2.567),
+        (1, 2, 3.234, 4.567),
+        (1, 3, 5.234, 6.567),
+        (1, 4, 7.234, 8.567),
+        (1, 5, 9.234, 10.567),
+        (2, 1, 1.234, 2.567),
+        (2, 2, 3.234, 4.567),
+        (2, 3, 5.234, 6.567),
+        (2, 4, 7.234, 8.567),
+        (2, 5, 9.234, 10.567),
+        (3, 1, 1.234, 2.567),
+        (3, 2, 3.234, 4.567),
+        (3, 3, 5.234, 6.567),
+        (3, 4, 7.234, 8.567),
+        (3, 5, 9.234, 10.567)],
+    ["sourceID", "filterID", "mjd", "aperMag1"])
 
-    df = spark_context.createDataFrame(
-        [
-            (1, 0.1, 0.2, 0.3),
-            (1, 0.5, 0.6, 0.7),
-            (2, 0.1, 0.2, 0.3),
-            (2, 0.9, 1.1, 1.2),
-        ],
-        ["id", "col1", "col2", "col3"]
-    )
 
-    return df
+def test_transform_passbands(sample_data, spark_context):
 
-
-def test_aggregate_by_key(spark_context, sample_data):
-
+    actual = transform_passbands(sample_data, filter_col="filterID", new_col_name="passband")
     expected = spark_context.createDataFrame(
-        [(1, [0.1, 0.5]),
-         (2, [0.1, 0.9])],
-        ["id", "col1"]
-    )
-
-    grouped = sample_data.groupBy("id")
-    actual = aggregate_by_key(grouped, "col1")
+        [
+        (1, 1, 1.234, 2.567, "Z"),
+        (1, 2, 3.234, 4.567, "Y"),
+        (1, 3, 5.234, 6.567, "J"),
+        (1, 4, 7.234, 8.567, "H"),
+        (1, 5, 9.234, 10.567, "K"),
+        (2, 1, 1.234, 2.567, "Z"),
+        (2, 2, 3.234, 4.567, "Y"),
+        (2, 3, 5.234, 6.567, "J"),
+        (2, 4, 7.234, 8.567, "H"),
+        (2, 5, 9.234, 10.567, "K"),
+        (3, 1, 1.234, 2.567, "Z"),
+        (3, 2, 3.234, 4.567, "Y"),
+        (3, 3, 5.234, 6.567, "J"),
+        (3, 4, 7.234, 8.567, "H"),
+        (3, 5, 9.234, 10.567, "K")],
+    ["sourceID", "filterID", "mjd", "aperMag1", "passband"])
 
     assertDataFrameEqual(actual, expected)
 
+def test_pivot_aggregate_columns(sample_data, spark_context):
+    df = transform_passbands(sample_data, filter_col="filterID", new_col_name="passband")
+    grouped = df.groupBy("sourceID")
+    actual = pivot_aggregate_col(grouped, col_name="mjd", pivot_on="passband")
+    expected = spark_context.createDataFrame(
+    [
+        (1, [7.234], [5.234], [9.234], [3.234], [1.234]),       
+        (2, [7.234], [5.234], [9.234], [3.234], [1.234]),
+        (3, [7.234], [5.234], [9.234], [3.234], [1.234])],
+    ["sourceID", "H_mjd", "J_mjd", "K_mjd", "Y_mjd", "Z_mjd"]
+)
+    
+    assertDataFrameEqual(actual, expected)
 
 def test_merge_all(spark_context, sample_data):
 
@@ -57,11 +87,13 @@ def test_merge_all(spark_context, sample_data):
     assertDataFrameEqual(merged, agg_df)
 
 
+
+
 def test_make_array_cols(spark_context, sample_data):
     expected = spark_context.createDataFrame(
-        [(1, [0.1, 0.5], [0.2, 0.6], [0.3, 0.7]),
-         (2, [0.1, 0.9], [0.2, 1.1], [0.3, 1.2])],
-        ["id", "col1", "col2", "col3"]
-    )
-    actual = make_array_cols(sample_data, key="id")
+    [(1, [7.234], [5.234], [9.234], [3.234], [1.234], [8.567], [6.567], [10.567], [4.567], [2.567]),
+     (2, [7.234], [5.234], [9.234], [3.234], [1.234], [8.567], [6.567], [10.567], [4.567], [2.567]),
+     (3, [7.234], [5.234], [9.234], [3.234], [1.234], [8.567], [6.567], [10.567], [4.567], [2.567])],
+     ["sourceID", "H_mjd", "J_mjd", "K_mjd", "Y_mjd", "Z_mjd", "H_aperMag1", "J_aperMag1", "K_aperMag1", "Y_aperMag1", "Z_aperMag1"])
+    actual = make_array_cols(sample_data, key="sourceID", filter_col="filterID")
     assertDataFrameEqual(actual, expected)

--- a/satools/test_array_columns.py
+++ b/satools/test_array_columns.py
@@ -94,3 +94,7 @@ def test_make_array_cols(spark_context, sample_data):
      ["sourceID", "H_mjd", "J_mjd", "K_mjd", "Y_mjd", "Z_mjd", "H_aperMag1", "J_aperMag1", "K_aperMag1", "Y_aperMag1", "Z_aperMag1"])
     actual = make_array_cols(sample_data, key="sourceID", filter_col="filterID")
     assertDataFrameEqual(actual, expected)
+
+@pytest.mark.xfail(raises=AssertionError)
+def test_make_array_cols_with_bad_colname(spark_context, sample_data):
+    make_array_cols(sample_data, key="this_key_should_throw_an_exception", filter_col="filterID", order_by="mjd")


### PR DESCRIPTION
Features:
* Pivot by passband
* Data sorted by mjd (or any other specified column)
* Columns matching regex pattern (default "aperMag|averageConf|modelDistSec") are cast to single precision `float` rather than `double`

Wrt sorting the dataframe on mjd - I have not formally validated that this ensures sorting in the resulting arrays, but looking at a few hundred rows it seems to work, and it is the behaviour I would expect. If it doesn't work, that will be obvious to users.

Code itself will need refactoring and optimisation to perform on VVV-scale data, but hopefully this captures the desired data model.


Resulting schema:
```
DataFrame[sourceID: bigint, 
H_mjd: array<double>, 
J_mjd: array<double>, 
K_mjd: array<double>, 
Y_mjd: array<double>, 
Z_mjd: array<double>, 
H_aperMag1: array<float>, 
J_aperMag1: array<float>, 
K_aperMag1: array<float>, 
Y_aperMag1: array<float>, 
Z_aperMag1: array<float>, 
H_aperMag1err: array<float>,
 J_aperMag1err: array<float>, 
K_aperMag1err: array<float>, 
Y_aperMag1err: array<float>, 
Z_aperMag1err: array<float>, 
H_aperMag2: array<float>,
 J_aperMag2: array<float>, 
K_aperMag2: array<float>, 
Y_aperMag2: array<float>, 
Z_aperMag2: array<float>, 
H_aperMag2err: array<float>, 
J_aperMag2err: array<float>, 
K_aperMag2err: array<float>, 
Y_aperMag2err: array<float>, 
Z_aperMag2err: array<float>, 
H_aperMag3: array<float>, 
J_aperMag3: array<float>, 
K_aperMag3: array<float>, 
Y_aperMag3: array<float>, 
Z_aperMag3: array<float>, 
H_aperMag3err: array<float>, 
J_aperMag3err: array<float>, 
K_aperMag3err: array<float>, 
Y_aperMag3err: array<float>, 
Z_aperMag3err: array<float>, 
H_errBits: array<bigint>, 
J_errBits: array<bigint>, 
K_errBits: array<bigint>, 
Y_errBits: array<bigint>, 
Z_errBits: array<bigint>, 
H_averageConf: array<float>, 
J_averageConf: array<float>, 
K_averageConf: array<float>, 
Y_averageConf: array<float>, 
Z_averageConf: array<float>, 
H_class: array<bigint>, 
J_class: array<bigint>, 
K_class: array<bigint>, 
Y_class: array<bigint>, 
Z_class: array<bigint>, 
H_classStat: array<double>, 
J_classStat: array<double>, 
K_classStat: array<double>, 
Y_classStat: array<double>, 
Z_classStat: array<double>, 
H_deprecated: array<bigint>, 
J_deprecated: array<bigint>, 
K_deprecated: array<bigint>, 
Y_deprecated: array<bigint>, 
Z_deprecated: array<bigint>, 
H_ppErrBits: array<bigint>, 
J_ppErrBits: array<bigint>, 
K_ppErrBits: array<bigint>, 
Y_ppErrBits: array<bigint>, 
Z_ppErrBits: array<bigint>, 
H_flag: array<bigint>, 
J_flag: array<bigint>, 
K_flag: array<bigint>, 
Y_flag: array<bigint>, 
Z_flag: array<bigint>, 
H_modelDistSecs: array<float>, 
J_modelDistSecs: array<float>, 
K_modelDistSecs: array<float>, 
Y_modelDistSecs: array<float>, 
Z_modelDistSecs: array<float>, 
H_objID: array<bigint>, 
J_objID: array<bigint>, 
K_objID: array<bigint>, 
Y_objID: array<bigint>, 
Z_objID: array<bigint>, 
H_multiframeID: array<bigint>, 
J_multiframeID: array<bigint>, 
K_multiframeID: array<bigint>, 
Y_multiframeID: array<bigint>, 
Z_multiframeID: array<bigint>, 
H_extNum: array<bigint>, 
J_extNum: array<bigint>, 
K_extNum: array<bigint>, 
Y_extNum: array<bigint>, 
Z_extNum: array<bigint>, 
H_seqNum: array<bigint>, 
J_seqNum: array<bigint>, 
K_seqNum: array<bigint>, 
Y_seqNum: array<bigint>, 
Z_seqNum: array<bigint>]
```